### PR TITLE
Fix flaky build due to GraphQL error

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,13 +37,12 @@ module.exports = {
       options: {
         entitiesArray: [
           {
-            url: `${SESSIONIZE_API}/all`,
+            url: `${SESSIONIZE_API}/speakers`,
             method: 'get',
             headers: {
               'Content-Type': 'application/json',
             },
-            typePrefix: 'sessionize__',
-            name: 'data',
+            name: 'speakers',
           },
           {
             url: `${SESSIONIZE_API}/sessions`,
@@ -51,8 +50,7 @@ module.exports = {
             headers: {
               'Content-Type': 'application/json',
             },
-            typePrefix: 'sessions__',
-            name: 'data',
+            name: 'sessions',
           },
         ],
       },

--- a/src/components/ScheduleTable.js
+++ b/src/components/ScheduleTable.js
@@ -6,27 +6,30 @@ import '../assets/css/schedule.css'
 export const ScheduleTable = () => (
   <StaticQuery
     // query={graphql`
-    //   query ScheduleQuery {
-    //     sessionsData {
-    //       sessions {
-    //         alternative_id
-    //         categories {
-    //           categoryItems {
+    //   query SessionsWithSchedule {
+    //     allSessions {
+    //       nodes {
+    //         sessions {
+    //           alternative_id
+    //           categories {
+    //             categoryItems {
+    //               name
+    //             }
+    //           }
+    //           endsAt
+    //           room
+    //           startsAt
+    //           title
+    //           speakers {
     //             name
     //           }
-    //         }
-    //         endsAt
-    //         room
-    //         startsAt
-    //         title
-    //         speakers {
-    //           name
     //         }
     //       }
     //     }
     //   }
     // `}
-    render={({ sessionsData: { sessions } }) => {
+    render={({ allSessions }) => {
+      const sessions = allSessions.nodes[0].sessions
       const MAIN_BALLROOM = 'Main Ballroom'
 
       const sortRooms = (a, b) =>

--- a/src/components/SessionsList.js
+++ b/src/components/SessionsList.js
@@ -8,103 +8,101 @@ import '../assets/css/session.css'
 export const SessionsList = () => (
   <StaticQuery
     query={graphql`
-      query SessionQuery {
-        sessionsData {
-          sessions {
-            alternative_id
-            speakers{
-              name
-            }
-            title
-            description
-            categories {
+      query SessionList {
+        allSessions(filter: {id: {ne: "dummy"}}) {
+          nodes {
+            sessions {
               alternative_id
-              categoryItems {
+              speakers {
                 name
+              }
+              title
+              description
+              categories {
+                alternative_id
+                categoryItems {
+                  name
+                }
               }
             }
           }
         }
       }
     `}
-    render={({ sessionsData: { sessions } }) => (
-      <div id="main" className="alt">
-        <section id="one" className="sessionList">
-          {sessions.map((session) => {
-            const shortTitle = session.title.split('').slice(0, 80)
-            if (shortTitle.length !== session.title.length) {
-              shortTitle.push('...')
-            }
-            const shortDescription =
-              session.description && session.description.split('').slice(0, 340)
-            if (
-              shortDescription &&
-              shortDescription.length !== session.description.length
-            ) {
-              shortDescription.push('...')
-            }
-            const level =
-              session.categories &&
-                session.categories.find((cat) => cat.alternative_id === LEVEL_ID)
-                ? session.categories.find(
-                  (cat) => cat.alternative_id === LEVEL_ID
-                ).categoryItems[0].name
-                : ''
-            const tags =
-              session.categories &&
-                session.categories.find((cat) => cat.alternative_id === TAG_ID)
-                ? session.categories
-                  .find((cat) => cat.alternative_id === TAG_ID)
-                  .categoryItems.map((item) => item.name)
-                : ''
-            const speakers = session.speakers
-              ? session.speakers.map((speaker) => speaker.name)
-              : []
+    render={({ allSessions }) => {
+      const sessions = allSessions.nodes[0].sessions
+      return (
+        <div id="main" className="alt">
+          <section id="one" className="sessionList">
+            {sessions.map((session) => {
+              const TITLE_CHAR_LIMIT = 80
+              const DESC_CHAR_LIMIT = 340
+              const shortTitle = session.title.length > TITLE_CHAR_LIMIT ? `${session.title.substring(0, TITLE_CHAR_LIMIT)}...` : session.title
+              const shortDesc = session.description.length > DESC_CHAR_LIMIT ? `${session.description.substring(0, DESC_CHAR_LIMIT)}...` : session.description
+              const level =
+                session.categories &&
+                  session.categories.find((cat) => cat.alternative_id === LEVEL_ID)
+                  ? session.categories.find(
+                    (cat) => cat.alternative_id === LEVEL_ID
+                  ).categoryItems[0].name
+                  : ''
+              const tags =
+                session.categories &&
+                  session.categories.find((cat) => cat.alternative_id === TAG_ID)
+                  ? session.categories
+                    .find((cat) => cat.alternative_id === TAG_ID)
+                    .categoryItems.map((item) => item.name)
+                  : ''
+              const speakers = session.speakers
+                ? session.speakers.map((speaker) => speaker.name)
+                : []
 
-            return (
-              <div className="inner session" key={session.alternative_id}>
-                <div className="sessionTitle">
-                  <h2>
-                    <Link
-                      title={session.title}
-                      className="title"
-                      to={`/session/${session.alternative_id}`}
-                    >
-                      {shortTitle}
-                    </Link>
-                  </h2>
-                  <div className="speakerLink">
-                    <div className="presentedBy">Presented by:</div>
-                    <div>
-                      {getSpeakerNameLink(speakers[0])}
-                      {speakers.length > 1 ? (
-                        <span> and {getSpeakerNameLink(speakers[1])}</span>
-                      ) : ''}
+              return (
+                <div className="inner session" key={session.alternative_id}>
+                  <div className="sessionTitle">
+                    <h2>
+                      <Link
+                        title={session.title}
+                        className="title"
+                        to={`/session/${session.alternative_id}`}
+                      >
+                        {shortTitle}
+                      </Link>
+                    </h2>
+                    <div className="speakerLink">
+                      <div className="presentedBy">Presented by:</div>
+                      <div>
+                        {getSpeakerNameLink(speakers[0])}
+                        {speakers.length > 1 ? (<span> and {getSpeakerNameLink(speakers[1])}</span>) : ''}
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div className="description">{shortDescription}</div>
-                <div className="levelTags">
-                  <span>
-                    <span className="info-prefix">Level: </span>
-                    {level}
-                  </span>
-                  {tags.length > 0 ? (
+                  <div className="description">{shortDesc}</div>
+                  <div className="levelTags">
                     <span>
-                      <span className="info-prefix">Tags:</span>
-                      {tags.map((tag, index) => (
-                        <span key={tag}>{`${index !== tags.length - 1 ? `${tag}, ` : tag}`}</span>
-                      ))}
+                      <span className="info-prefix">Level: </span>
+                      {level}
                     </span>
-                  ) : (
-                    ''
-                  )}
+                    {tags.length > 0 ? (
+                      <span>
+                        <span className="info-prefix">Tags:</span>
+                        {tags.map((tag, index) => (
+                          <React.Fragment key={tag}>
+                            <span>{tag}</span>
+                            {index !== tags.length - 1 ? ', ' : ''}
+                          </React.Fragment>
+                        ))}
+                      </span>
+                    ) : (
+                      ''
+                    )}
+                  </div>
                 </div>
-              </div>
-            )
-          })}
-        </section>
-      </div>
-    )}
+              )
+            })}
+          </section>
+        </div>
+      )
+    }}
   />
 )

--- a/src/components/SpeakersList.js
+++ b/src/components/SpeakersList.js
@@ -8,41 +8,47 @@ import { BlueLogo } from '../assets/images'
 export const SpeakersList = () => (
   <StaticQuery
     query={graphql`
-      query SpeakerListQuery {
-        sessionizeData {
-          speakers {
-            tagLine
-            profilePicture
-            fullName
+      query SpeakerList {
+        allSpeakers(filter: {id: {ne: "dummy"}}) {
+          nodes {
+            alternative_id
             firstName
             lastName
-            sessions
+            fullName
+            bio
+            tagLine
+            profilePicture
             links {
-              url
               linkType
+              title
+              url
+            }
+            sessions {
+              alternative_id
+              name
             }
           }
-          sessions {
-            alternative_id
-            title
+        }
+        allSessions(filter: {id: {ne: "dummy"}}) {
+          nodes {
+            sessions {
+              title
+              alternative_id
+            }
           }
         }
       }
     `}
-    render={({ sessionizeData: { speakers, sessions } }) => {
+    render={({ allSpeakers, allSessions }) => {
+      const sessions = allSessions.nodes[0].sessions
+      const speakers = allSpeakers.nodes
       const sessionTitlesById = sessions
-        .map((session) => Object.values(session))
         .reduce((acc, cur) => {
-          const shortTitle = cur[1].split('').slice(0, 35)
-          if (shortTitle.length !== cur[1].length) {
-            shortTitle.push('...')
-          }
+          const TITLE_CHAR_LIMIT = 35
+          const shortTitle = cur.title.length > TITLE_CHAR_LIMIT ? `${cur.title.substring(0, 35)}...` : cur.title
           return {
             ...acc,
-            [cur[0]]: {
-              shortTitle: shortTitle.join(''),
-              title: cur[1],
-            },
+            [cur.alternative_id]: { shortTitle, title: cur.title },
           }
         }, {})
 
@@ -79,7 +85,7 @@ export const SpeakersList = () => (
                       )}
                     </div>
                     <div className="session-links">
-                      {speaker.sessions.map((sessionId) => (
+                      {speaker.sessions.map(({ alternative_id: sessionId }) => (
                         <Link
                           title={sessionTitlesById[sessionId].title}
                           key={sessionId}

--- a/src/templates/blogList.js
+++ b/src/templates/blogList.js
@@ -33,7 +33,7 @@ export default BlogList
 export const pageQuery = graphql`
   query ($skip: Int!, $limit: Int!) {
     allMarkdownRemark(
-      sort: { fields: [frontmatter___publishedDate], order: DESC }
+      sort: { frontmatter: { publishedDate: DESC } }
       filter: { frontmatter: { template: { eq: "blog" } } }
       skip: $skip
       limit: $limit

--- a/src/templates/session.js
+++ b/src/templates/session.js
@@ -6,10 +6,12 @@ import { LEVEL_ID, TAG_ID } from '../assets/data/levelAndTagId'
 import '../assets/css/session.css'
 
 const SessionTemplate = ({
-  data: { sessionsData, sessionizeData },
+  data: { allSessions, allSpeakers },
   pageContext: { slug },
 }) => {
-  const session = sessionsData.sessions.find(
+  allSessions = allSessions.nodes[0].sessions
+  allSpeakers = allSpeakers.nodes
+  const session = allSessions.find(
     (session) => session.alternative_id === slug
   )
   const title = session ? session.title : ''
@@ -34,7 +36,7 @@ const SessionTemplate = ({
       : ''
   const speaker1 =
     session && session.speakers && session.speakers[0]
-      ? sessionizeData.speakers.find(
+      ? allSpeakers.find(
         (speaker) =>
           speaker.alternative_id === session.speakers[0].alternative_id
       )
@@ -102,35 +104,33 @@ const SessionTemplate = ({
 export default SessionTemplate
 
 export const query = graphql`
-  query NewSessionQuery {
-    sessionizeData {
-      speakers {
+  query SessionPageQuery {
+    allSpeakers(filter: {id: {ne: "dummy"}}) {
+      nodes {
         alternative_id
         firstName
         lastName
-        bio
-        tagLine
-        profilePicture
-        isTopSpeaker
         fullName
       }
     }
-    sessionsData {
-      sessions {
-        alternative_id
-        description
-        speakers {
+    allSessions(filter: {id: {ne: "dummy"}}) {
+      nodes {
+        sessions {
           alternative_id
-          name
-        }
-        categories {
-          alternative_id
-          categoryItems {
+          description
+          speakers {
+            alternative_id
             name
           }
+          categories {
+            alternative_id
+            categoryItems {
+              name
+            }
+          }
+          title
+          isServiceSession
         }
-        title
-        isServiceSession
       }
     }
   }

--- a/src/templates/speaker.js
+++ b/src/templates/speaker.js
@@ -7,22 +7,19 @@ import { BlueLogo } from '../assets/images'
 import '../assets/css/speaker.css'
 
 const SpeakerTemplate = ({
-  data: { sessionizeData },
+  data: { allSessions, allSpeakers },
   pageContext: { slug },
 }) => {
-  const speaker = sessionizeData.speakers.find((speaker) => {
-    const speakerSlug = getSpeakerSlug(speaker.fullName)
-    return speakerSlug === slug
-  })
-  const speakerSessions = sessionizeData.sessions.filter((session) =>
-    speaker.sessions.includes(parseInt(session.alternative_id))
+  allSessions = allSessions.nodes[0].sessions
+  allSpeakers = allSpeakers.nodes
+  const speaker = allSpeakers.find((speaker) => slug == getSpeakerSlug(speaker.fullName))
+  const speakerSessions = allSessions.filter((session) =>
+    speaker.sessions.map(s => String(s.alternative_id)).includes(session.alternative_id)
   )
   const sessionText = `Session${speakerSessions.length > 1 ? 's' : ''}:`
 
   const pageTitle = `${speaker.fullName} - Momentum 2023 Speaker`
-  const sessionList = speakerSessions
-    .map((session) => `"${session.title}"`)
-    .join(', ')
+  const sessionList = speakerSessions.map((session) => `"${session.title}"`).join(', ')
   return (
     <Wrapper
       title={speaker.fullName}
@@ -66,25 +63,32 @@ const SpeakerTemplate = ({
 export default SpeakerTemplate
 
 export const query = graphql`
-  query SpeakertQuery {
-    sessionizeData {
-      speakers {
-        fullName
+  query SpeakerPage {
+    allSpeakers(filter: {id: {ne: "dummy"}}) {
+      nodes {
+        alternative_id
         firstName
         lastName
-        tagLine
+        fullName
         bio
+        tagLine
         profilePicture
-        sessions
         links {
-          url
           linkType
+          title
+          url
+        }
+        sessions {
+          alternative_id
         }
       }
-      sessions {
-        alternative_id
-        title
-        description
+    }
+    allSessions(filter: {id: {ne: "dummy"}}) {
+      nodes {
+        sessions {
+          alternative_id
+          title
+        }
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,25 +49,25 @@
     picocolors "^1.0.0"
 
 "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.24.8.tgz#f9196455334c38d059ac8b1a16a51decda9d30d3"
-  integrity sha512-c4IM7OTg6k1Q+AJ153e2mc2QVTezTwnb4VzquwcyiEzGnW0Kedv4do/TrkU98qPeC5LNiMt/QXwIjzYXLBpyZg==
+  version "7.24.9"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.24.9.tgz#53eee4e68f1c1d0282aa0eb05ddb02d033fc43a0"
+  integrity sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==
 
 "@babel/core@^7.14.0", "@babel/core@^7.20.12":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.8.tgz#c24f83985214f599cee5fc26d393d9ab320342f4"
-  integrity sha512-6AWcmZC/MZCO0yKys4uhg5NlxL0ESF3K6IAaoQ+xSXvPyPyxNWRafP+GDbI88Oh68O7QkJgmEtedWPM9U0pZNg==
+  version "7.24.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.9.tgz#dc07c9d307162c97fa9484ea997ade65841c7c82"
+  integrity sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.24.7"
-    "@babel/generator" "^7.24.8"
+    "@babel/generator" "^7.24.9"
     "@babel/helper-compilation-targets" "^7.24.8"
-    "@babel/helper-module-transforms" "^7.24.8"
+    "@babel/helper-module-transforms" "^7.24.9"
     "@babel/helpers" "^7.24.8"
     "@babel/parser" "^7.24.8"
     "@babel/template" "^7.24.7"
     "@babel/traverse" "^7.24.8"
-    "@babel/types" "^7.24.8"
+    "@babel/types" "^7.24.9"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -83,12 +83,12 @@
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.1"
 
-"@babel/generator@^7.14.0", "@babel/generator@^7.20.14", "@babel/generator@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.24.8.tgz#1802d6ac4d77a9199c75ae3eb6a08336e5d1d39a"
-  integrity sha512-47DG+6F5SzOi0uEvK4wMShmn5yY0mVjVJoWTphdY2B4Rx9wHgjK7Yhtr0ru6nE+sn0v38mzrWOlah0p/YlHHOQ==
+"@babel/generator@^7.14.0", "@babel/generator@^7.20.14", "@babel/generator@^7.24.8", "@babel/generator@^7.24.9":
+  version "7.24.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.24.10.tgz#a4ab681ec2a78bbb9ba22a3941195e28a81d8e76"
+  integrity sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==
   dependencies:
-    "@babel/types" "^7.24.8"
+    "@babel/types" "^7.24.9"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^2.5.1"
@@ -192,10 +192,10 @@
     "@babel/traverse" "^7.24.7"
     "@babel/types" "^7.24.7"
 
-"@babel/helper-module-transforms@^7.24.7", "@babel/helper-module-transforms@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.24.8.tgz#b1f2df4f96f3465b0d035b697ec86cb51ff348fe"
-  integrity sha512-m4vWKVqvkVAWLXfHCCfff2luJj86U+J0/x+0N3ArG/tP0Fq7zky2dYwMbtPmkc/oulkkbjdL3uWzuoBwQ8R00Q==
+"@babel/helper-module-transforms@^7.24.7", "@babel/helper-module-transforms@^7.24.8", "@babel/helper-module-transforms@^7.24.9":
+  version "7.24.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz#e13d26306b89eea569180868e652e7f514de9d29"
+  integrity sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==
   dependencies:
     "@babel/helper-environment-visitor" "^7.24.7"
     "@babel/helper-module-imports" "^7.24.7"
@@ -1139,10 +1139,10 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.20.7", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.4.4":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.8.tgz#d51ffa9043b17d36622efa44e861a49e69e130a8"
-  integrity sha512-SkSBEHwwJRU52QEVZBmMBnE5Ux2/6WU1grdYyOhpbCNxbmJrDuDCphBzKZSO3taf0zztp+qkWlymE5tVL5l0TA==
+"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.20.7", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.24.9", "@babel/types@^7.4.4":
+  version "7.24.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.9.tgz#228ce953d7b0d16646e755acf204f4cf3d08cc73"
+  integrity sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==
   dependencies:
     "@babel/helper-string-parser" "^7.24.8"
     "@babel/helper-validator-identifier" "^7.24.7"
@@ -1200,31 +1200,31 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@fortawesome/fontawesome-common-types@6.5.2":
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz#eaf2f5699f73cef198454ebc0c414e3688898179"
-  integrity sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==
+"@fortawesome/fontawesome-common-types@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz#31ab07ca6a06358c5de4d295d4711b675006163f"
+  integrity sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==
 
 "@fortawesome/fontawesome-svg-core@^6.5.2":
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz#4b42de71e196039b0d5ccf88559b8044e3296c21"
-  integrity sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz#2a24c32ef92136e98eae2ff334a27145188295ff"
+  integrity sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.5.2"
+    "@fortawesome/fontawesome-common-types" "6.6.0"
 
 "@fortawesome/free-brands-svg-icons@^6.5.2":
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.5.2.tgz#bfca0cebd2c4713dc93244e1fa8b384f1f023587"
-  integrity sha512-zi5FNYdmKLnEc0jc0uuHH17kz/hfYTg4Uei0wMGzcoCL/4d3WM3u1VMc0iGGa31HuhV5i7ZK8ZlTCQrHqRHSGQ==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.6.0.tgz#2797f2cc66d21e7e47fa64e680b8835e8d30e825"
+  integrity sha512-1MPD8lMNW/earme4OQi1IFHtmHUwAKgghXlNwWi9GO7QkTfD+IIaYpIai4m2YJEzqfEji3jFHX1DZI5pbY/biQ==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.5.2"
+    "@fortawesome/fontawesome-common-types" "6.6.0"
 
 "@fortawesome/free-solid-svg-icons@^6.5.2":
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz#9b40b077b27400a5e9fcbf2d15b986c7be69e9ca"
-  integrity sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz#061751ca43be4c4d814f0adbda8f006164ec9f3b"
+  integrity sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.5.2"
+    "@fortawesome/fontawesome-common-types" "6.6.0"
 
 "@fortawesome/react-fontawesome@^0.2.2":
   version "0.2.2"
@@ -2219,9 +2219,9 @@
     "@types/estree" "*"
 
 "@types/eslint@*":
-  version "8.56.10"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.10.tgz#eb2370a73bf04a901eeba8f22595c7ee0f7eb58d"
-  integrity sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-9.6.0.tgz#51d4fe4d0316da9e9f2c80884f2c20ed5fb022ff"
+  integrity sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -2297,9 +2297,9 @@
     "@types/node" "*"
 
 "@types/lodash@^4.14.92":
-  version "4.17.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.6.tgz#193ced6a40c8006cfc1ca3f4553444fb38f0e543"
-  integrity sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==
+  version "4.17.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.7.tgz#2f776bcb53adc9e13b2c0dfd493dfcbd7de43612"
+  integrity sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==
 
 "@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
   version "3.0.15"
@@ -2329,9 +2329,9 @@
     form-data "^4.0.0"
 
 "@types/node@*", "@types/node@>=10.0.0":
-  version "20.14.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.10.tgz#a1a218290f1b6428682e3af044785e5874db469a"
-  integrity sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==
+  version "20.14.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.11.tgz#09b300423343460455043ddd4d0ded6ac579b74b"
+  integrity sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==
   dependencies:
     undici-types "~5.26.4"
 
@@ -2727,14 +2727,14 @@ ajv@^6.10.0, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
     uri-js "^4.2.2"
 
 ajv@^8.0.0, ajv@^8.0.1, ajv@^8.9.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.16.0.tgz#22e2a92b94f005f7e0f9c9d39652ef0b8f6f0cb4"
-  integrity sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
   dependencies:
     fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
-    uri-js "^4.4.1"
 
 anser@^2.1.1:
   version "2.1.1"
@@ -2959,16 +2959,6 @@ array.prototype.flatmap@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz#c9a7c6831db8e719d6ce639190146c24bbd3e527"
   integrity sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    es-shim-unscopables "^1.0.0"
-
-array.prototype.toreversed@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz#b989a6bf35c4c5051e1dc0325151bf8088954eba"
-  integrity sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
@@ -3755,9 +3745,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001640:
-  version "1.0.30001641"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz#3572862cd18befae3f637f2a1101cc033c6782ac"
-  integrity sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==
+  version "1.0.30001643"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz#9c004caef315de9452ab970c3da71085f8241dbd"
+  integrity sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -4866,9 +4856,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.820:
-  version "1.4.826"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.826.tgz#096426d3333718f867b16cc5195c8e56f75c998e"
-  integrity sha512-zULpSu/wQI4X9qWAHabbi0ZUfJ/bEFTA6bfdXlg6HSf5XS7A8vMdzpJC4r5Ws/5E5NGdrNHmXgvGewGuHMxhPQ==
+  version "1.4.833"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.833.tgz#463a37538b40ece154d4741eac4e9f076d9c3b32"
+  integrity sha512-aVGP9xK70Ysrzip1m5LoJjCp1EDrYzZ7Pg/O3QR1h3PAhmc8SNfSXV3kmmtkg5rNO42EcTYmLX3eFMgqALlGIA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -5264,28 +5254,28 @@ eslint-plugin-react-hooks@^4.6.0:
   integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
 
 eslint-plugin-react@^7.19.0, eslint-plugin-react@^7.32.2:
-  version "7.34.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.34.3.tgz#9965f27bd1250a787b5d4cfcc765e5a5d58dcb7b"
-  integrity sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==
+  version "7.35.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz#00b1e4559896710e58af6358898f2ff917ea4c41"
+  integrity sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==
   dependencies:
     array-includes "^3.1.8"
     array.prototype.findlast "^1.2.5"
     array.prototype.flatmap "^1.3.2"
-    array.prototype.toreversed "^1.1.2"
     array.prototype.tosorted "^1.1.4"
     doctrine "^2.1.0"
     es-iterator-helpers "^1.0.19"
     estraverse "^5.3.0"
+    hasown "^2.0.2"
     jsx-ast-utils "^2.4.1 || ^3.0.0"
     minimatch "^3.1.2"
     object.entries "^1.1.8"
     object.fromentries "^2.0.8"
-    object.hasown "^1.1.4"
     object.values "^1.2.0"
     prop-types "^15.8.1"
     resolve "^2.0.0-next.5"
     semver "^6.3.1"
     string.prototype.matchall "^4.0.11"
+    string.prototype.repeat "^1.0.0"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -5707,6 +5697,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-uri@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
+  integrity sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==
 
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -7210,9 +7205,9 @@ immer@^9.0.7:
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 immutable@^4.0.0:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.6.tgz#6a05f7858213238e587fb83586ffa3b4b27f0447"
-  integrity sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
+  integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
 
 immutable@~3.7.6:
   version "3.7.6"
@@ -7418,9 +7413,9 @@ is-ci@^2.0.0:
     ci-info "^2.0.0"
 
 is-core-module@^2.13.0, is-core-module@^2.13.1:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.14.0.tgz#43b8ef9f46a6a08888db67b1ffd4ec9e3dfd59d1"
-  integrity sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.0.tgz#71c72ec5442ace7e76b306e9d48db361f22699ea"
+  integrity sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==
   dependencies:
     hasown "^2.0.2"
 
@@ -8654,10 +8649,15 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
+mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+"mime-db@>= 1.43.0 < 2":
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.53.0.tgz#3cb63cd820fc29896d9d4e8c32ab4fcd74ccb447"
+  integrity sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==
 
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.30, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
@@ -8792,9 +8792,9 @@ msgpackr-extract@^3.0.2:
     "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.3"
 
 msgpackr@^1.5.4:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.10.2.tgz#a73de4767f76659e8c69cf9c80fdfce83937a44a"
-  integrity sha512-L60rsPynBvNE+8BWipKKZ9jHcSGbtyJYIwjRq0VrIvQ08cRjntGXJYW/tmciZ2IHWIY8WEW32Qa2xbh5+SKBZA==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.11.0.tgz#8321d52333048cadc749f56385e3231e65337091"
+  integrity sha512-I8qXuuALqJe5laEBYoFykChhSXLikZmUhccjGsPuSJ/7uPip2TJ7lwdIQwWSAi0jGZDXv4WOP8Qg65QZRuXxXw==
   optionalDependencies:
     msgpackr-extract "^3.0.2"
 
@@ -8918,9 +8918,9 @@ node-addon-api@^6.1.0:
   integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
 node-addon-api@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.0.tgz#71f609369379c08e251c558527a107107b5e0fdb"
-  integrity sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 node-fetch@^2.6.11, node-fetch@^2.6.12:
   version "2.7.0"
@@ -8960,9 +8960,9 @@ node-object-hash@^2.3.10:
   integrity sha512-jY5dPJzw6NHd/KPSfPKJ+IHoFS81/tJ43r34ZeNMXGzCOM8jwQDCD12HYayKIB6MuznrnqIYy2e891NA2g0ibA==
 
 node-releases@^2.0.14:
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
-  integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
+  integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
 
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
@@ -9106,15 +9106,6 @@ object.groupby@^1.0.1:
     call-bind "^1.0.7"
     define-properties "^1.2.1"
     es-abstract "^1.23.2"
-
-object.hasown@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.4.tgz#e270ae377e4c120cdcb7656ce66884a6218283dc"
-  integrity sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==
-  dependencies:
-    define-properties "^1.2.1"
-    es-abstract "^1.23.2"
-    es-object-atoms "^1.0.0"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -10737,9 +10728,9 @@ semver@^6.0.0, semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
-  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.18.0:
   version "0.18.0"
@@ -11259,6 +11250,14 @@ string.prototype.matchall@^4.0.11:
     set-function-name "^2.0.2"
     side-channel "^1.0.6"
 
+string.prototype.repeat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz#e90872ee0308b29435aa26275f6e1b762daee01a"
+  integrity sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+
 string.prototype.trim@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz#b6fa326d72d2c78b6df02f7759c73f8f6274faa4"
@@ -11548,9 +11547,9 @@ terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.9:
     terser "^5.26.0"
 
 terser@^5.2.0, terser@^5.26.0:
-  version "5.31.2"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.2.tgz#b5ca188107b706084dca82f988089fa6102eba11"
-  integrity sha512-LGyRZVFm/QElZHy/CPr/O4eNZOZIzsrQ92y4v9UJe/pFJjypje2yI3C2FmPtvUEnhadlSbmG2nXtdcjHOjCfxw==
+  version "5.31.3"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.3.tgz#b24b7beb46062f4653f049eea4f0cd165d0f0c38"
+  integrity sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -12032,7 +12031,7 @@ upper-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
-uri-js@^4.2.2, uri-js@^4.4.1:
+uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==


### PR DESCRIPTION
The build pipeline has been incredibly flaky. The log indicates that our GraphQL queries on Sessionize speakers and sessions has a high chance of failing to retrieve the necessary data, thus leading to build errors like data is `null` or `undefined`

**→ Solution**: The `gatsby-apiserver-source` plugins also provides an "all\<name\>" GraphQL entity which consistently includes all the needed information (i.e. query `allSpeakers` as opposed to `speakers`). I hypothesized that: for some reason, when Gatsby "convert" the 'all' version to the non-all version, data tends to go missing.

Anyhow, even though the 'all' entity queries aren't clean, they produce more consistent results and thus are the fix to our problem

Example of old GraphQL query
```graphql
query Old {
  sessions(id: {ne: "dummy"}) {
    sessions {
      alternative_id
      title
      description
      status
    }
  }
}
```

Example of new GraphQL query (notice the use of the `all` entity + adding the `nodes` field)
```graphql
query New {
  allSessions(id: {ne: "dummy"}) {
    nodes {
      sessions {
        alternative_id
        description
        title
        status
      }
    }
  }
}
```

With the new query, the data access pattern changes a little bit
```js
const queryResult = await grapql(`...`)
const speakers = queryResult.data.allSpeakers.nodes
const sessions = queryResult.data.allSessions.nodes[0].sessions
```