### PR TITLE
Trim speaker names before sorting on Speakers page

### DIFF
--- a/src/components/SpeakersList.js
+++ b/src/components/SpeakersList.js
@@ -42,6 +42,23 @@ export const SpeakersList = () => (
     render={({ allSpeakers, allSessions }) => {
       const sessions = allSessions.nodes[0].sessions
       const speakers = allSpeakers.nodes
+        .map((speaker) => {
+          const firstName = speaker.firstName ? speaker.firstName.trim() : speaker.firstName
+          const lastName = speaker.lastName ? speaker.lastName.trim() : speaker.lastName
+          const fullName = speaker.fullName ? speaker.fullName.trim() : speaker.fullName
+
+          return {
+            ...speaker,
+            firstName,
+            lastName,
+            fullName,
+          }
+        })
+        .sort((a, b) => {
+          const nameA = a.fullName ? a.fullName.toLowerCase() : ''
+          const nameB = b.fullName ? b.fullName.toLowerCase() : ''
+          return nameA.localeCompare(nameB)
+        })
       const sessionTitlesById = sessions
         .reduce((acc, cur) => {
           const TITLE_CHAR_LIMIT = 35

--- a/src/utils/getSpeakerSlug.js
+++ b/src/utils/getSpeakerSlug.js
@@ -1,1 +1,2 @@
-export const getSpeakerSlug = (name) => name ? name.split(' ').join('_') : '';
+export const getSpeakerSlug = (name) =>
+  name ? name.trim().split(/\s+/).join('_') : ''


### PR DESCRIPTION
## Summary
- trim speaker names sourced from Sessionize before rendering
- sort the trimmed speaker list alphabetically to restore the intended order
- normalize speaker slugs so leading whitespace does not affect generated URLs

## Testing
- yarn lint *(fails: repository currently contains pre-existing lint issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e48250f5848329ac5ec02a3cc23e54