### PR TITLE
Add CFP link to homepage for 2026

### DIFF
--- a/src/assets/css/header.css
+++ b/src/assets/css/header.css
@@ -11,7 +11,7 @@
   top: 0;
   width: 100%;
   max-width: 100vw; /* Prevent overflow */
-  overflow-x: hidden; /* Hide any overflow */
+  overflow: hidden; /* Hide any overflow */
   box-sizing: border-box;
   z-index: 1000;
   background-color: #303658;

--- a/src/components/CallForPresenters.js
+++ b/src/components/CallForPresenters.js
@@ -7,7 +7,7 @@ export const CallForPresentersClosed = () => (
         <h3>Call for Speakers Now Closed!</h3>
       </header>
       <p>
-        Our 2025 Call for Speakers is now closed. Thank you to everyone who took the time and effort to submit their
+        Our 2026 Call for Speakers is now closed. Thank you to everyone who took the time and effort to submit their
         abstracts!
       </p>
     </article>
@@ -21,18 +21,24 @@ export const CallForPresentersOpen = () => (
         <h3>Call for Speakers Now Open!</h3>
       </header>
       <p>
-        If you would like to be considered for presenting at Momentum 2025, put your best ideas together and get them
-        over to us on Sessionize . Wow us with your expertise, or show us something we haven't seen. Our CFP is open
-        until May 31st!
-        <br />
-        <a href="https://sessionize.com/momentum-2025/" target="_blank" rel="noreferrer">
-          Link to CFP
+        If you would like to be considered for presenting at Momentum 2026, put your best ideas together and get them
+        over to us on Sessionize. Wow us with your expertise, or show us something we haven't seen. Our CFP is open
+        until <strong>June 1st!</strong>
+      </p>
+      <p>
+        <a
+          href="https://sessionize.com/momentum-2026/"
+          target="_blank"
+          rel="noreferrer"
+          style={{ marginBottom: '1rem', textDecoration: 'none', borderBottom: 'none' }}
+        >
+          <button className='banner-btn'>Submit a Session</button>
         </a>
       </p>
       <p>
         Need help with your abstract?{' '}
-        <a href="https://momentumdevcon.slack.com/" target="_blank" rel="noreferrer">
-          Join our Slack group
+        <a href="https://discord.momentumdevcon.com/" target="_blank" rel="noreferrer">
+          Join our Discord
         </a>{' '}
         to talk about your ideas and get help from organizers and other speakers.
       </p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,16 +3,17 @@ import Helmet from 'react-helmet'
 import { graphql } from 'gatsby'
 import { metaContent } from '../assets/data/metaContent.js'
 
-import { Banner, Layout, LatestBlogPost, WhatIsMomentum, ThankYou} from '../components'
+import { Banner, CallForPresentersOpen, Layout, LatestBlogPost, WhatIsMomentum } from '../components'
 
 const HomeIndex = ({ data }) => (
   <Layout>
     <Helmet title="Momentum Developer Conference" meta={[...metaContent]} />
     <Banner />
     <div id="main">
+      <CallForPresentersOpen />
       {/*<WhovaCallout />
     <TicketsCTA />*/}
-      <ThankYou />
+      {/* <ThankYou /> */}
       <WhatIsMomentum />
       <LatestBlogPost posts={data.allMarkdownRemark.edges} />
     </div>


### PR DESCRIPTION
- Hide ThankYou section
- Add and update CFP link for 2026
  - Update year, end date (moved to June 1st so it lands on Monday)
  - Switch from Slack to Discord
  - Update formatting, CTA button style
- Fix header vertical overflow

<img width="1075" height="1198" alt="image" src="https://github.com/user-attachments/assets/21106843-d8d7-4c61-a5b7-811b2ddb198b" />
